### PR TITLE
fix - [WARNING] The expression ${version} is deprecated. Please use

### DIFF
--- a/contact-srv-client/pom.xml
+++ b/contact-srv-client/pom.xml
@@ -265,7 +265,7 @@
 		<dependency>
 			<groupId>com.sap.hana.cloud.samples</groupId>
 			<artifactId>contact-srv-api</artifactId>
-			<version>${version}</version>
+			<version>${project.version}</version>
 		</dependency>
 
 		<!-- Tiles -->

--- a/contact-srv-provider/pom.xml
+++ b/contact-srv-provider/pom.xml
@@ -378,7 +378,7 @@
 		<dependency>
 			<groupId>com.sap.hana.cloud.samples</groupId>
 			<artifactId>contact-srv-api</artifactId>
-			<version>${version}</version>
+			<version>${project.version}</version>
 		</dependency>
 
 


### PR DESCRIPTION
maven build shows "[WARNING] The expression ${version} is deprecated. Please use ${project.version} instead."

This commit gets rid of the warning